### PR TITLE
Fix empty span node is inserted

### DIFF
--- a/src/content_editable.js
+++ b/src/content_editable.js
@@ -66,6 +66,7 @@
       position.left -= this.$el.offset().left;
       position.top += $node.height() - this.$el.offset().top;
       position.lineHeight = $node.height();
+      $node.remove();
       var dir = this.$el.attr('dir') || this.$el.css('direction');
       if (dir === 'rtl') { position.left -= this.listView.$el.width(); }
       return position;


### PR DESCRIPTION
An empty span node was inserted in content editable upon completion. This fix remove the span node that was created only to compute the position of the caret.