### PR TITLE
Fix completion with enter key

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -106,6 +106,7 @@
     // Suppress searching if it returns true.
     _skipSearch: function (clickEvent) {
       switch (clickEvent.keyCode) {
+        case 13: // ENTER
         case 40: // DOWN
         case 38: // UP
           return true;

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -271,7 +271,7 @@
     _enter: function () {
       var datum = this.data[parseInt(this._getActiveElement().data('index'), 10)];
       this.completer.select(datum.value, datum.strategy);
-      this._setScroll();
+      this.deactivate();
     },
 
     _pageup: function () {


### PR DESCRIPTION
The plugin is working great when the completion is done with the mouse (i.e. clicking on a suggestion with the mouse), but is buggy when a suggestion is chosen with the enter key.