### PR TITLE
Yield the search term to the template function

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -221,7 +221,7 @@
           self.dropdown.clear();
           self._clearAtNext = false;
         }
-        self.dropdown.render(self._zip(data, strategy));
+        self.dropdown.render(self._zip(data, strategy, term));
         if (!stillSearching) {
           // The last callback in the current lock.
           free();
@@ -236,9 +236,9 @@
     //
     //  this._zip(['a', 'b'], 's');
     //  //=> [{ value: 'a', strategy: 's' }, { value: 'b', strategy: 's' }]
-    _zip: function (data, strategy) {
+    _zip: function (data, strategy, term) {
       return $.map(data, function (value) {
-        return { value: value, strategy: strategy };
+        return { value: value, strategy: strategy, term: term };
       });
     }
   });

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -385,7 +385,7 @@
         index = this.data.length;
         this.data.push(datum);
         html += '<li class="textcomplete-item" data-index="' + index + '"><a>';
-        html +=   datum.strategy.template(datum.value);
+        html +=   datum.strategy.template(datum.value, datum.term);
         html += '</a></li>';
       }
       return html;


### PR DESCRIPTION
This yields the search query that was used to the template function. I'm using it like so to highlight the term in the list item:

```js
    template: function (val, query) {
      var start = val.search(query);
      return val.substr(0, start) + '<strong>' + query + '</strong>' + val.substr(start + query.length);
    }
```

Maybe there's a better alternative api, like yielding the match results (basically these same indexes) to the template function, but this leaves it more open ended.