### PR TITLE
Add package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "author": "Yuku Takahashi <taka84u9@gmail.com>",
   "name": "jquery-textcomplete",
+  "main": "dist/jquery.textcomplete",
   "version": "0.5.1",
   "homepage": "http://yuku-t.com/jquery-textcomplete",
   "repository": {


### PR DESCRIPTION
This adds the distributable script as the main field in the package.json. This means that CommonJS loaders like browserify and webpack will be able to use this simply by doing `require('jquery-textcomplete')`.