### PR TITLE
Add support for a "no results" message like the header/footer

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -52,7 +52,7 @@
     if (option.listPosition) { this.setPosition = option.listPosition; }
     if (option.height) { this.$el.height(option.height); }
     var self = this;
-    $.each(['maxCount', 'placement', 'footer', 'header', 'className'], function (_i, name) {
+    $.each(['maxCount', 'placement', 'footer', 'header', 'noResultsMessage', 'className'], function (_i, name) {
       if (option[name] != null) { self[name] = option[name]; }
     });
     this._bindEvents(element);
@@ -120,6 +120,8 @@
           this._activateIndexedItem();
         }
         this._setScroll();
+      } else if (this.noResultsMessage) {
+        this._renderNoResultsMessage(unzippedData);
       } else if (this.shown) {
         this.deactivate();
       }
@@ -150,7 +152,7 @@
       this.$el.html('');
       this.data = [];
       this._index = 0;
-      this._$header = this._$footer = null;
+      this._$header = this._$footer = this._$noResultsMessage = null;
     },
 
     activate: function () {
@@ -205,6 +207,7 @@
     _data:    null,  // Currently shown zipped data.
     _index:   null,
     _$header: null,
+    _$noResultsMessage: null,
     _$footer: null,
 
     // Private methods
@@ -408,6 +411,16 @@
         }
         var html = $.isFunction(this.footer) ? this.footer(unzippedData) : this.footer;
         this._$footer.html(html);
+      }
+    },
+
+    _renderNoResultsMessage: function (unzippedData) {
+      if (this.noResultsMessage) {
+        if (!this._$noResultsMessage) {
+          this._$noResultsMessage = $('<li class="textcomplete-no-results-message"></li>').appendTo(this.$el);
+        }
+        var html = $.isFunction(this.noResultsMessage) ? this.noResultsMessage(unzippedData) : this.noResultsMessage;
+        this._$noResultsMessage.html(html);
       }
     },
 


### PR DESCRIPTION
This adds support for a "no results" message when the user's query doesn't match anything. When a `noResultsMessage` option is supplied, instead of disappearing, the dropdown will inform the user that their query has no results. The implementation is along the lines of the header and footer messages.

I'm open to suggestions of course.

![](https://www.dropbox.com/s/8f099idi35k7cwt/Screenshot%202015-06-12%2010.41.11.png?dl=1)