### PR TITLE
fix a regex in an example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Synopsis
 
 ```js
 $('textarea').textcomplete([{
-    match: /(^|\s)(\w{2,})$/,
+    match: /(^|\b)(\w{2,})$/,
     search: function (term, callback) {
         var words = ['google', 'facebook', 'github', 'microsoft', 'yahoo'];
         callback($.map(words, function (word) {


### PR DESCRIPTION
Use `\b` instead of `\s`.

`\s` matches a space character and completion deletes it (e.g. ` google` => `google`).
`\b` matches **the position** of word boundaries but does not match any character.

Anyway, thank you for your great work :+1: 