### PR TITLE
Calculate positioning relative to the appendTo element

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -75,14 +75,19 @@
       throw new Error('Not implemented');
     },
 
-    // Returns the caret's relative coordinates from body's left top corner.
-    //
-    // FIXME: Calculate the left top corner of `this.option.appendTo` element.
+    // Returns the caret's relative coordinates from the top left corner of the
+    // closest common ancestor element.
     getCaretPosition: function () {
       var position = this._getCaretRelativePosition();
+      var commonAncestor = this.$el.parents()
+        .filter(this.option.appendTo.parents().addBack())
+        .first()
+        .children()
+        .offsetParent();
       var offset = this.$el.offset();
-      position.top += offset.top;
-      position.left += offset.left;
+      var commonOffset = commonAncestor.offset();
+      position.top += offset.top - commonOffset.top;
+      position.left += offset.left - commonOffset.left;
       return position;
     },
 

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -138,8 +138,12 @@
       // This can't be done during init, as textcomplete may be used on multiple elements on the same page
       // Because the same dropdown is reused behind the scenes, we need to recheck every time the dropdown is showed
       var position = 'absolute';
-      // Check if input or one of its parents has positioning we need to care about
-      this.$inputEl.add(this.$inputEl.parents()).each(function() {
+      // Check if input or one of its parents that are not shared with the
+      // dropdown has positioning we need to care about.
+      this.$inputEl
+        .add(this.$inputEl.parents())
+        .not(this.$el.parents())
+        .each(function() {
         if($(this).css('position') === 'absolute') // The element has absolute positioning, so it's all OK
           return false;
         if($(this).css('position') === 'fixed') {


### PR DESCRIPTION
The previous positioning did not take the `appendTo` option into
account. Consequently, the dropdown was not positioned properly in some
cases, for example inside of fixed Bootstrap dialogs. Appending to the
body breaks there when the dialog opens after the user scrolled the page
a bit.

With this patch, the dropdown can be appended to the dialog instead of
the body. The dropdown itself then does not need `position: fixed` and
always appears in the right spot.

Fixes the issue in the comments of #125