### PR TITLE
added condition to ignore skipUnchangedTerm for empty text

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -150,7 +150,7 @@
       if (searchQuery.length) {
         var term = searchQuery[1];
         // Ignore shift-key, ctrl-key and so on.
-        if (skipUnchangedTerm && this._term === term) { return; }
+        if (skipUnchangedTerm && this._term === term && term !== "") { return; }
         this._term = term;
         this._search.apply(this, searchQuery);
       } else {


### PR DESCRIPTION
I found an issue on a specific issue. When the user is interested in poppping suggestions (all available) after a comma (example, tags complete), the plugin fails to do so on the second time because the remembered term, and the new one are both "". This happens when the user types nothing, just use the arrow and enter or the mouse.
And example match would be: /(,\s?)(\w*)$/
