### PR TITLE
add the option to move the popup from bottom to top if it is clipped (off screen)

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -213,6 +213,7 @@
     _search: lock(function (free, strategy, term, match) {
       var self = this;
       strategy.search(term, function (data, stillSearching) {
+        var checkPlacementAfterRender = !self.dropdown.shown;
         if (!self.dropdown.shown) {
           self.dropdown.activate();
         }
@@ -223,6 +224,9 @@
         }
         self.dropdown.setPosition(self.adapter.getCaretPosition());
         self.dropdown.render(self._zip(data, strategy, term));
+        if(checkPlacementAfterRender && self.dropdown._elementOffBottomOfScreen()){
+          self.dropdown.setPosition(self.adapter.getCaretPosition());
+        }
         if (!stillSearching) {
           // The last callback in the current lock.
           free();

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -450,10 +450,17 @@
       }
     },
 
+    // return true only if the popup leaves at least minGap (default is 0)
+    // pixels off the bottom. Used to avoid popup clipping
+    _elementOffBottomOfScreen: function(minGap){
+      return (this.$el.offsetParent().height() - this.$el.offset().top - this.$el.height() < (minGap || 0) );
+    },
+
     _applyPlacement: function (position) {
       // If the 'placement' option set to 'top', move the position above the element.
-      if (this.placement.indexOf('top') !== -1) {
-        // Overwrite the position object to set the 'bottom' property instead of the top.
+      if ( (this.placement.indexOf('top') !== -1) || (this.option.topOnClip && this._elementOffBottomOfScreen())){
+        // Overwrite the position object to set the 'bottom' property instead of the top
+        // or if the popup runs off the screen the to topOnClip option is set
         position = {
           top: 'auto',
           bottom: this.$el.parent().height() - position.top + position.lineHeight,


### PR DESCRIPTION
when the popup is positioned at the bottom and too long, it is clipped and some entries are not visible.
This fix add the option 'topOnClip' which makes the plugin check after render if the drop down runs off the bottom of the screen and fix the position if it is by placing it on top