### PR TITLE
Fix top position issue when window is scrolled up and parents has fix position.

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -141,8 +141,8 @@
         if($(this).css('position') === 'absolute') // The element has absolute positioning, so it's all OK
           return false;
         if($(this).css('position') === 'fixed') {
-          pos.top -= $(window).scrollTop();
-          pos.left -= $(window).scrollLeft();					
+          pos.top -= $window.scrollTop();
+          pos.left -= $window.scrollLeft();					
           position = 'fixed';
           return false;
         }

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -132,8 +132,6 @@
     },
 
     setPosition: function (pos) {
-      this.$el.css(this._applyPlacement(pos));
-
       // Make the dropdown fixed if the input is also fixed
       // This can't be done during init, as textcomplete may be used on multiple elements on the same page
       // Because the same dropdown is reused behind the scenes, we need to recheck every time the dropdown is showed
@@ -143,10 +141,13 @@
         if($(this).css('position') === 'absolute') // The element has absolute positioning, so it's all OK
           return false;
         if($(this).css('position') === 'fixed') {
+          pos.top -= $(window).scrollTop();
+          pos.left -= $(window).scrollLeft();					
           position = 'fixed';
           return false;
         }
       });
+      this.$el.css(this._applyPlacement(pos));
       this.$el.css({ position: position }); // Update positioning
 
       return this;


### PR DESCRIPTION
Fix top position issue when window is scrolled up and the input or textarea's parents have fixed position setting. Which causes problem when input/textarea is inside  Bootstrap modal dialog, when the main page has been scrolled up. The drop list position will be far blow the expected position.

This is caused by the wrong offset calculation. jQuery offset is related to document instead of view port. And in fixed position the top is related to view port. 

This fixes following issues: 

Problem with placement top #125
Calculate positioning relative to the appendTo element #206