### PR TITLE
Add deactivate method to Completer

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -142,6 +142,12 @@
       this.$el = this.adapter = this.dropdown = null;
     },
 
+    deactivate: function () {
+      if (this.dropdown) {
+        this.dropdown.deactivate();
+      }
+    },
+
     // Invoke textcomplete.
     trigger: function (text, skipUnchangedTerm) {
       if (!this.dropdown) { this.initialize(); }


### PR DESCRIPTION
Hey @yuku-t, great library! I'm pretty new to it, so I might be missing something. 

My use case is that I have a `textarea` inside of a modal. The modal has `fixed` positioning in it's ancestry, so the dropdown is left floating in space when the modal is scrolled within its fixed outer container. (I've deduced that this is happening because there is a `position: fixed` up the parent chain.)

To get around this, I want to deactivate the dropdown anytime the user scrolls the modal. Something like this:

```javascript
$(".modal").on("scroll", function() {
  $(this).find("textarea").textcomplete("deactivate");
});
```

I've added at `deactivate()` method to the `Completer` in this pull request to enable this. It seems to be working well for me.