### PR TITLE
FIX: avoid dropdown bumping into right edge of window

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -121,6 +121,7 @@
         if (contentsHtml) {
           this._renderContents(contentsHtml);
           this._fitToBottom();
+          this._fitToRight();
           this._activateIndexedItem();
         }
         this._setScroll();
@@ -447,6 +448,17 @@
       var height = this.$el.height();
       if ((this.$el.position().top + height) > windowScrollBottom) {
         this.$el.offset({top: windowScrollBottom - height});
+      }
+    },
+
+    _fitToRight: function() {
+      // We don't know how wide our content is until the browser positions us, and at that point it clips us
+      // to the document width so we don't know if we would have overrun it. As a heuristic to avoid that clipping
+      // (which makes our elements wrap onto the next line and corrupt the next item), if we're close to the right
+      // edge, move left. We don't know how far to move left, so just keep nudging a bit.
+      var tolerance = 30; // pixels. Make wider than vertical scrollbar because we might not be able to use that space.
+      while (this.$el.offset().left + this.$el.width() > $window.width() - tolerance) {
+        this.$el.offset({left: this.$el.offset().left - tolerance});
       }
     },
 


### PR DESCRIPTION
If the autocomplete dropdown is posititioned too far right, the
container div for the dropdown gets clipped at the window width,
forcing its contained elements to wrap onto the next line.

The fix is to move farther left in this case; ideally we'd just
position at (left = window.width - dropdown.width); however AFAIK
there's no way to get the true width of the dropdown, only the clipped
width, because by the time you can ask the browser its width it's
already been clipped. So instead we employ a heuristic: if it's too
close to the right edge of the window (in my case, with a browser
window 1280px wide and a vertical scrollbar showing, it seems to get
clipped at 1264px, so "too close" must be > 16px; I set it to 30 here)
then we assume we got clipped, we move somewhat left which gives us
room to grow, and we see if we're still clipped, repeating as
necessary.