### PR TITLE
Fix dropdown showing out of viewport

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -480,7 +480,7 @@
     },
 
     _applyPlacement: function (position) {
-      position.height = Math.min(this.$el.parent().height(), $(window).height());
+      position.height = Math.min(this.$el.parent().height(), $window.height());
       // If the 'placement' option set to 'top', move the position above the element.
       if (this.placement.indexOf('top') !== -1) {
         // Overwrite the position object to set the 'bottom' property instead of the top.

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -480,12 +480,13 @@
     },
 
     _applyPlacement: function (position) {
+      position.height = Math.min(this.$el.parent().height(), $(window).height());
       // If the 'placement' option set to 'top', move the position above the element.
       if (this.placement.indexOf('top') !== -1) {
         // Overwrite the position object to set the 'bottom' property instead of the top.
         position = {
           top: 'auto',
-          bottom: this.$el.parent().height() - position.top + position.lineHeight,
+          bottom: position.height - position.top + position.lineHeight,
           left: position.left
         };
       } else {


### PR DESCRIPTION
When 'top' is passed into options and you have a document height that's larger than the viewport, the dropdown can show outside of the screen because the parent height can be 4400px (see a Discourse site like [Cloud9 community](https://community.c9.io)). This takes the min of the window height and the parent height so it ensures the dropdown will show in the viewport.