### PR TITLE
Fix #285: Remove dependency on Redmine / issue_notes undefined

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -16,7 +16,7 @@
   $.extend(CKEditor.prototype, $.fn.textcomplete.ContentEditable.prototype, {
     _bindEvents: function () {
       var $this = this;
-      CKEDITOR.instances["issue_notes"].on('key', function(event) {
+      this.option.ckeditor_instance.on('key', function(event) {
         var domEvent = event.data;
         $this._onKeyup(domEvent);
         if ($this.completer.dropdown.shown && $this._skipSearch(domEvent)) {

--- a/src/completer.js
+++ b/src/completer.js
@@ -91,6 +91,7 @@
             self.$el = $(event.editor.editable().$);
             if (!self.option.adapter) {
               self.option.adapter = $.fn.textcomplete['CKEditor'];
+              self.option.ckeditor_instance = event.editor;
             }
             self.initialize();
           });


### PR DESCRIPTION
Some Redmine specific code slipped in which is now removed.
The CKEditor is stored in an option to be available in the ckeditor plugin.