### PR TITLE
Skip search after pressing shift, ctrl, alt, pageup and pagedown keys

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -116,6 +116,11 @@
       switch (clickEvent.keyCode) {
         case 9:  // TAB
         case 13: // ENTER
+        case 16: // SHIFT
+        case 17: // CTRL
+        case 18: // ALT
+        case 33: // PAGEUP
+        case 34: // PAGEDOWN
         case 40: // DOWN
         case 38: // UP
         case 27: // ESC


### PR DESCRIPTION
Searching is fired after dropdown is scrolled by page up/down. As the result, scroll position of the dropdown is reset. I think those keys should be added to `_skipSearch`. Also, the same occurs after pressing only non-printable key, e.g. shift/ctlr/alt key.