### PR TITLE
Attach textcomplete to the active CKEditor only

### DIFF
--- a/src/completer.js
+++ b/src/completer.js
@@ -85,7 +85,7 @@
 
       // Special handling for CKEditor: lazy init on instance load
       if ((!this.option.adapter || this.option.adapter == 'CKEditor') && typeof CKEDITOR != 'undefined' && (this.$el.is('textarea'))) {
-        CKEDITOR.on("instanceReady", function(event) {
+        CKEDITOR.once("instanceReady", function(event) {
           event.editor.once("focus", function(event2) {
             // replace the element with the Iframe element and flag it as CKEditor
             self.$el = $(event.editor.editable().$);


### PR DESCRIPTION
Prevent memory leaks in single page application environment, when multiple CKEditor instances are initialized an destroyed one after another (As if posting several comments using CKEditor in a popup screen).